### PR TITLE
fix: Correct indentation error causing for loop ending prematurely :bug:

### DIFF
--- a/certbot_dns_directadmin/dns_directadmin.py
+++ b/certbot_dns_directadmin/dns_directadmin.py
@@ -179,8 +179,8 @@ class _DirectadminClient:
             if record_name is domain or record_name.endswith("." + domain):
                 directadmin_zone = main_domain
                 directadmin_name = record_name[: -len(domain) - 1]
-            if main_domain != domain:
-                is_pointer = "yes"
+                if main_domain != domain:
+                    is_pointer = "yes"
                 break
         if directadmin_name is None:
             raise DirectAdminClientException(


### PR DESCRIPTION
In some cases, when you are trying to generate a certificate it ends with the error:
`Encountered exception during recovery: certbot.errors.PluginError: Error adding TXT record: Unable to determine DNS Zone from DirectAdmin` because of bug:

Let's assume you have domains `['example1.com', 'example2.com', 'sub.example2.com', 'example3.com']`. When you decide to create a certificate for example3.com, the script ends the loop prematurely with a break clause when it detects the first domain with a pointer (in this example: sub.example2.com) and raises the error mentioned above.

PR includes some indentation adjustments in `certbot_dns_directadmin/dns_directadmin.py` which fixes that bug.